### PR TITLE
Apply sourcemaps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/node_modules/

--- a/index.js
+++ b/index.js
@@ -1,22 +1,52 @@
+'use strict';
+
 var regenerator = require('regenerator'),
-    detectCompile = /\bfunction\s*\*|\basync\s+function\b/,
-    detectRuntime = /\bregeneratorRuntime\b/;
+    recast = require('recast');
+
+var detectCompile = /\bfunction\s*\*|\basync\s+function\b/
+  , detectRuntime = /\bregeneratorRuntime\b/;
+
+var SourceMapGenerator = require('source-map').SourceMapGenerator;
+var SourceMapConsumer = require('source-map').SourceMapConsumer;
+
+// borrowed technique from https://github.com/sindresorhus/gulp-regenerator/blob/master/index.js
+function compile(source, filename) {
+    var ast = regenerator.transform(recast.parse(source, {
+        sourceFileName: filename
+    }));
+
+    return recast.print(ast, {
+        sourceMapName: filename
+    });
+}
+
+function applyMap(outgoing, incoming) {
+    var g = SourceMapGenerator.fromSourceMap(new SourceMapConsumer(outgoing));
+    g.applySourceMap(new SourceMapConsumer(incoming));
+    return JSON.parse(g.toString());
+}
 
 module.exports = function (source, map) {
 
     this.cacheable && this.cacheable();
 
-    if (detectCompile.test(source)) {
-        var result = regenerator.compile(source);
-        if (result.code !== source && detectRuntime.test(result.code))  {
-            return "var regneratorRuntime = require('regenerator/runtime');\n"
-                   + result.code;
-        }
+    if (!detectCompile.test(source)) {
+        this.callback(null, source, map);
+        return;
     }
-    
-    this.async().apply(
-        this, [null].concat(Array.prototype.slice.call(arguments))
-    );
+
+    var result = compile(source, this.resourcePath);
+
+    if (detectRuntime.test(result.code)) {
+        result.code = "var regeneratorRuntime = require('regenerator/runtime');\n" + result.code;
+    }
+
+    if (this.sourceMap && map != null) {
+        if (result.map == null) { result.map = map; }
+        else { result.map = applyMap(result.map, map); }
+    }
+
+    this.callback(null, result.code, result.map);
 
 };
 

--- a/package.json
+++ b/package.json
@@ -19,5 +19,9 @@
   "license": "ISC",
   "peerDependencies": {
     "regenerator": "^0.8.0"
+  },
+  "dependencies": {
+    "recast": "^0.10.11",
+    "source-map": "^0.4.2"
   }
 }


### PR DESCRIPTION
Will correctly apply source maps to previous loaders, to allow webpack loader chaining.

(borrowed Recast AST technique to force a source map from gulp-regenerator)

Also added a `.gitignore` of `node_modules`, but I can reset the branch pointer if you don't want that.
