### PR TITLE
typo in the local var name "regeneratorRuntime"

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports = function (source, map) {
     if (detectCompile.test(source)) {
         var result = regenerator.compile(source);
         if (result.code !== source && detectRuntime.test(result.code))  {
-            return "var regneratorRuntime = require('regenerator/runtime');\n"
+            return "var regeneratorRuntime = require('regenerator/runtime');\n"
                    + result.code;
         }
     }


### PR DESCRIPTION
It works with this typo because of global regeneratorRuntime var set in module. But I think, that the local var is better :) And fixes "unused var" IDE message.